### PR TITLE
ES6-ify: Use ES6 keywords and features

### DIFF
--- a/src/boot/main.ts
+++ b/src/boot/main.ts
@@ -8,7 +8,7 @@
 
 import { GameManager } from './../gameManager';
 
-declare var module: any;
+declare let module: any;
 
 /*
  * Singleton object. Since GameManager doesn't need multiple instances we can use it as singleton object.

--- a/src/components/creeps/creepAction.ts
+++ b/src/components/creeps/creepAction.ts
@@ -43,7 +43,7 @@ export class CreepAction implements ICreepAction {
   }
 
   public moveToRenew(): void {
-    if (this.tryRenew() == ERR_NOT_IN_RANGE) {
+    if (this.tryRenew() === ERR_NOT_IN_RANGE) {
       this.moveTo(this.renewStation);
     }
   }

--- a/src/components/creeps/creepManager.ts
+++ b/src/components/creeps/creepManager.ts
@@ -6,9 +6,9 @@ import { Harvester } from './harvester';
 
 export namespace CreepManager {
 
-  export var creeps: { [creepName: string]: Creep };
-  export var creepNames: string[] = [];
-  export var creepCount: number;
+  export let creeps: { [creepName: string]: Creep };
+  export let creepNames: string[] = [];
+  export let creepCount: number;
 
   export function loadCreeps(): void {
     creeps = Game.creeps;
@@ -31,7 +31,7 @@ export namespace CreepManager {
       renew_station_id: SpawnManager.getFirstSpawn().id
     };
 
-    var status: number | string = SpawnManager.getFirstSpawn().canCreateCreep(bodyParts, name);
+    let status: number | string = SpawnManager.getFirstSpawn().canCreateCreep(bodyParts, name);
     if (status == OK) {
       status = SpawnManager.getFirstSpawn().createCreep(bodyParts, name, properties);
 

--- a/src/components/creeps/harvester.ts
+++ b/src/components/creeps/harvester.ts
@@ -28,7 +28,7 @@ export class Harvester extends CreepAction implements IHarvester, ICreepAction {
   }
 
   public isBagFull(): boolean {
-    return (this.creep.carry.energy == this.creep.carryCapacity);
+    return (this.creep.carry.energy === this.creep.carryCapacity);
   }
 
   public tryHarvest(): number {
@@ -36,7 +36,7 @@ export class Harvester extends CreepAction implements IHarvester, ICreepAction {
   }
 
   public moveToHarvest(): void {
-    if (this.tryHarvest() == ERR_NOT_IN_RANGE) {
+    if (this.tryHarvest() === ERR_NOT_IN_RANGE) {
       this.moveTo(this.targetSource);
     }
   }
@@ -46,7 +46,7 @@ export class Harvester extends CreepAction implements IHarvester, ICreepAction {
   }
 
   public moveToDropEnergy(): void {
-    if (this.tryEnergyDropOff() == ERR_NOT_IN_RANGE) {
+    if (this.tryEnergyDropOff() === ERR_NOT_IN_RANGE) {
       this.moveTo(this.targetEnergyDropOff);
     }
   }

--- a/src/components/rooms/roomManager.ts
+++ b/src/components/rooms/roomManager.ts
@@ -2,8 +2,8 @@ import { Config } from './../../config/config';
 
 export namespace RoomManager {
 
-  export var rooms: { [roomName: string]: Room };
-  export var roomNames: string[] = [];
+  export let rooms: { [roomName: string]: Room };
+  export let roomNames: string[] = [];
 
   export function loadRooms() {
     rooms = Game.rooms;

--- a/src/components/sources/sourceManager.ts
+++ b/src/components/sources/sourceManager.ts
@@ -3,8 +3,8 @@ import { RoomManager } from './../rooms/roomManager';
 
 export namespace SourceManager {
 
-  export var sources: Source[];
-  export var sourceCount: number;
+  export let sources: Source[];
+  export let sourceCount: number;
 
   export function loadSources() {
     sources = RoomManager.getFirstRoom().find<Source>(FIND_SOURCES_ACTIVE);

--- a/src/components/spawns/spawnManager.ts
+++ b/src/components/spawns/spawnManager.ts
@@ -2,9 +2,9 @@ import { Config } from './../../config/config';
 
 export namespace SpawnManager {
 
-  export var spawns: { [spawnName: string]: Spawn };
-  export var spawnNames: string[] = [];
-  export var spawnCount: number;
+  export let spawns: { [spawnName: string]: Spawn };
+  export let spawnNames: string[] = [];
+  export let spawnCount: number;
 
   export function loadSpawns() {
     spawns = Game.spawns;

--- a/src/shared/memoryManager.ts
+++ b/src/shared/memoryManager.ts
@@ -1,6 +1,6 @@
 export namespace MemoryManager {
 
-  export var memory: Memory;
+  export let memory: Memory;
 
   export function loadMemory(): void {
     this.memory = Memory;


### PR DESCRIPTION
This should replace most of the `var` keywords with `let` (or `const` if necessary), and replaces `==` to a much more stricter `===`

Let me know if stuff breaks.
