### PR TITLE
gulpfile fixes and improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "through2": "^2.0.1",
     "tsconfig-glob": "^0.4.3",
     "tslint": "^3.13.0",
-    "tsproject": "^1.2.1",
     "typings": "^1.3.0"
   }
 }


### PR DESCRIPTION
ensured that a failed compiling would stop subsequent tasks such as uploading, and that the watch task would not prematurely exit.
