### PR TITLE
Transition to TypeScript 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@
 
 This starter kit is a modified version of the original [Screeps/TypeScript sample project](https://github.com/MarkoSulamagi/Screeps-typescript-sample-project) by [Marko Sulamägi](https://github.com/MarkoSulamagi).
 
-## Getting Started
+## Notice
 
-After you create a spawn, this bot will create 4 creeps which will start to harvest the closest source. The bots harvest, then transfer energy back to Spawn. If a creep's lifespan has depleted enough, it will refill in Spawn.
+This repository recently transitioned to TypeScript 2, complete with all sorts of new features including the ability to flatten your code with Webpack. Those who still wish to use TS1 should checkout the [`ts1-legacy`](https://github.com/screepers/screeps-typescript-starter/tree/ts1-legacy) branch. Any notable changes in `master` may be backported into the legacy branch.
+
+To learn more about TypeScript 2, [click here](https://blogs.msdn.microsoft.com/typescript/2016/07/11/announcing-typescript-2-0-beta/).
+
+## Getting Started
 
 ### Requirements
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ After you create a spawn, this bot will create 4 creeps which will start to harv
 ### Requirements
 
 * [Node.js](https://nodejs.org/en/) (v4.0.0+)
-* Gulp - `npm install -g gulp`
-* TypeScript - `npm install -g typescript`
-* Typings - `npm install -g typings`
+* Gulp 4.0+ - `sudo npm install -g gulpjs/gulp.git#4.0`
 
 ### Quick setup
 

--- a/config.example.json
+++ b/config.example.json
@@ -7,11 +7,15 @@
   "targets": {
     "dev": {
       "branch": "default",
-      "bundle": false
+      "bundle": false,
+      "lint": true,
+      "lintRequired": false
     },
     "prod": {
       "branch": "default",
-      "bundle": true
+      "bundle": true,
+      "lint": true,
+      "lintRequired": true
     }
   }
 }

--- a/config.example.json
+++ b/config.example.json
@@ -1,7 +1,7 @@
 {
   "user": {
     "email": "YOUR_USERNAME",
-    "password": "YOUR_PASSWORD",
+    "password": "YOUR_PASSWORD"
   },
   "defaultTarget": "dev",
   "targets": {

--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,17 @@
 {
-  "email": "YOUR_USERNAME",
-  "password": "YOUR_PASSWORD",
-  "branch": "default"
+  "user": {
+    "email": "YOUR_USERNAME",
+    "password": "YOUR_PASSWORD",
+  },
+  "defaultTarget": "dev",
+  "targets": {
+    "dev": {
+      "branch": "default",
+      "bundle": false
+    },
+    "prod": {
+      "branch": "default",
+      "bundle": true
+    }
+  }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,7 @@
+/*jshint esversion: 6, node: true */
 'use strict';
 
+const gutil = require('gulp-util');
 const clean = require('gulp-clean');
 const gulp = require('gulp');
 const gulpDotFlatten = require('./libs/gulp-dot-flatten.js');
@@ -10,55 +12,125 @@ const PluginError = require('gulp-util').PluginError;
 const ts = require('gulp-typescript');
 const tslint = require('gulp-tslint');
 const tsconfig = ts.createProject('tsconfig.json', { typescript: require('typescript') });
+const webpack = require('webpack-stream');
 
-const config = require('./config.json');
+/********/
+/* INIT */
+/********/
 
-gulp.task('lint', () => {
-  return gulp.src('./src/**/*.ts')
+let config;
+
+try {
+  config = require('./config.json');
+} catch (error) {
+  if (error.code == "MODULE_NOT_FOUND") {
+    gutil.log(gutil.colors.red('ERROR'), 'Could not find file "config.json"');
+  } else {
+    gutil.log(error);
+  }
+  process.exit();
+}
+
+if (!config.user || !config.user.email || !config.user.password) {
+  gutil.log(gutil.colors.red('ERROR'), 'Invalid "config.json" file: cannot find user credentials');
+  process.exit();
+}
+
+if (!config.targets) {
+  gutil.log(gutil.colors.red('ERROR'), 'Invalid "config.json" file: cannot find build targets');
+  process.exit();
+}
+
+if (!config.defaultTarget || !config.targets[config.defaultTarget]) {
+  gutil.log(gutil.colors.red('ERROR'), 'Invalid "config.json" file: cannot find default build target');
+  process.exit();
+}
+
+gutil.log('Successfully loaded', gutil.colors.magenta('config.json'));
+
+if (gutil.env.target) {
+  if (!config.targets[gutil.env.target]) {
+    gutil.log(gutil.colors.red('ERROR'), 'Invalid build target "' + gutil.env.target + '"');
+    gutil.log('Valid build targets are:', '"' + Object.keys(config.targets).join('", "') + '"');
+    process.exit();
+  }
+  gutil.log('Using selected build target', gutil.colors.magenta(gutil.env.target));
+} else {
+  gutil.log('Using default build target', gutil.colors.magenta(config.defaultTarget));
+}
+
+const buildTarget = gutil.env.target || config.defaultTarget;
+const buildConfig = config.targets[buildTarget];
+
+/*********/
+/* TASKS */
+/*********/
+
+gulp.task('lint', function() {
+  return gulp.src('src/**/*.ts')
     .pipe(tslint({ formatter: 'prose' }))
     .pipe(tslint.report({
       summarizeFailureOutput: true,
       emitError: false
-    }))
+    }));
 });
 
-gulp.task('clean', () => {
-  return gulp.src('dist', { read: false })
+gulp.task('clean', function() {
+  return gulp.src(['dist/tmp/', 'dist/' + buildTarget], { read: false, allowEmpty: true })
     .pipe(clean());
 });
 
-let compileFailed = false;
+gulp.task('compile-bundled', gulp.series(gulp.parallel('lint', 'clean'), function bundle() {
+  const webpackConfig = require('./webpack.config.js');
+  return gulp.src('src/main.ts')
+    .pipe(webpack(webpackConfig))
+    .pipe(gulp.dest('dist/' + buildTarget));
+}));
 
-gulp.task('compile', ['lint', 'clean'], () => {
-  compileFailed = false;
-  return tsconfig.src()
-    .pipe(ts(tsconfig))
-    .on('error', (err) => { compileFailed = true; })
-    .js.pipe(gulp.dest('dist/js'));
+gulp.task('compile-flattened', gulp.series(
+  gulp.parallel('lint', 'clean'),
+  function tsc() {
+    global.compileFailed = false;
+    return tsconfig.src()
+      .pipe(ts(tsconfig))
+      .on('error', (err) => global.compileFailed = true)
+      .js.pipe(gulp.dest('dist/tmp'));
+  },
+  function checkTsc(done) {
+    if (!global.compileFailed) {
+      return done();
+    }
+    throw new PluginError("gulp-typescript", "failed to compile: not executing further tasks");
+  },
+  function flatten() {
+    return gulp.src('dist/tmp/**/*.js')
+      .pipe(gulpDotFlatten(0))
+      .pipe(gulp.dest('dist/' + buildTarget));
+  }
+));
+
+gulp.task('compile', gulp.series(buildConfig.bundle ? 'compile-bundled' : 'compile-flattened'));
+
+gulp.task('upload', gulp.series('compile', function uploading() {
+  return gulp.src('dist/' + buildTarget + '/*.js')
+    .pipe(gulpRename((path) => path.extname = ''))
+    .pipe(gulpScreepsUpload(config.user.email, config.user.password, buildConfig.branch, 0));
+}));
+
+gulp.task('watch', function () {
+  gulp.watch('src/**/*.ts', gulp.series('build'))
+    .on('all', function(event, path, stats) {
+      console.log('');
+      gutil.log(gutil.colors.green('File ' + path + ' was ' + event + 'ed, running tasks...'));
+    })
+    .on('error', function() {
+      gutil.log(gutil.colors.green('Error during build tasks: aborting'));
+    });
 });
 
-gulp.task('checked-compile', ['compile'], () => {
-  if (!compileFailed)
-    return true;
-  throw new PluginError("gulp-typescript", "failed to compile: not executing further tasks");
-})
-
-gulp.task('flatten', ['checked-compile'], () => {
-  return gulp.src('./dist/js/**/*.js')
-    .pipe(gulpDotFlatten(0))
-    .pipe(gulp.dest('./dist/flat'))
-});
-
-gulp.task('upload', ['flatten'], () => {
-  return gulp.src('./dist/flat/*.js')
-    .pipe(gulpRename(path => { path.extname = ''; }))
-    .pipe(gulpScreepsUpload(config.email, config.password, config.branch, 0))
-});
-
-gulp.task('watch', () => {
-  gulp.watch('./src/**/*.ts', ['build']);
-});
-
-gulp.task('build', ['upload']);
-gulp.task('test', ['lint']);
-gulp.task('default', ['watch']);
+gulp.task('build', gulp.series('upload', function buildDone(done) {
+  gutil.log(gutil.colors.green('Build done'));
+  return done();
+}));
+gulp.task('test', gulp.series('lint'));
+gulp.task('default', gulp.series('watch'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -66,13 +66,19 @@ const buildConfig = config.targets[buildTarget];
 /* TASKS */
 /*********/
 
-gulp.task('lint', function() {
-  return gulp.src('src/**/*.ts')
-    .pipe(tslint({ formatter: 'prose' }))
-    .pipe(tslint.report({
-      summarizeFailureOutput: true,
-      emitError: false
-    }));
+gulp.task('lint', function(done) {
+  if (buildConfig.lint) {
+    gutil.log('linting ...');
+    return gulp.src('src/**/*.ts')
+      .pipe(tslint({ formatter: 'prose' }))
+      .pipe(tslint.report({
+        summarizeFailureOutput: true,
+        emitError: buildConfig.lintRequired === true
+      }));
+  } else {
+    gutil.log('skipped lint, according to config');
+    return done();
+  }
 });
 
 gulp.task('clean', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,8 +18,8 @@ gulp.task('lint', () => {
     .pipe(tslint({ formatter: 'prose' }))
     .pipe(tslint.report({
       summarizeFailureOutput: true,
-      emitError: false
-    }))
+      emitError: false,
+    }));
 });
 
 gulp.task('clean', () => {
@@ -40,19 +40,19 @@ gulp.task('compile', ['lint', 'clean'], () => {
 gulp.task('checked-compile', ['compile'], () => {
   if (!compileFailed)
     return true;
-  throw new PluginError("gulp-typescript", "failed to compile: not executing further tasks");
-})
+  throw new PluginError('gulp-typescript', 'failed to compile: not executing further tasks');
+});
 
 gulp.task('flatten', ['checked-compile'], () => {
   return gulp.src('./dist/js/**/*.js')
     .pipe(gulpDotFlatten(0))
-    .pipe(gulp.dest('./dist/flat'))
+    .pipe(gulp.dest('./dist/flat'));
 });
 
 gulp.task('upload', ['flatten'], () => {
   return gulp.src('./dist/flat/*.js')
     .pipe(gulpRename(path => { path.extname = ''; }))
-    .pipe(gulpScreepsUpload(config.email, config.password, config.branch, 0))
+    .pipe(gulpScreepsUpload(config.email, config.password, config.branch, 0));
 });
 
 gulp.task('watch', () => {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,18 +8,10 @@ const gulpScreepsUpload = require('./libs/gulp-screeps-upload.js');
 const path = require('path');
 const PluginError = require('gulp-util').PluginError;
 const ts = require('gulp-typescript');
-const tsconfigGlob = require('tsconfig-glob');
 const tslint = require('gulp-tslint');
-const tsconfig = ts.createProject('tsconfig.json');
+const tsconfig = ts.createProject('tsconfig.json', { typescript: require('typescript') });
 
 const config = require('./config.json');
-
-gulp.task('update-tsconfig-files', () => {
-  return tsconfigGlob({
-    configPath: '.',
-    indent: 2
-  });
-});
 
 gulp.task('lint', () => {
   return gulp.src('./src/**/*.ts')
@@ -37,12 +29,12 @@ gulp.task('clean', () => {
 
 let compileFailed = false;
 
-gulp.task('compile', ['lint', 'clean', 'update-tsconfig-files'], () => {
+gulp.task('compile', ['lint', 'clean'], () => {
   compileFailed = false;
   return tsconfig.src()
     .pipe(ts(tsconfig))
     .on('error', (err) => { compileFailed = true; })
-    .js.pipe(gulp.dest('dist'));
+    .js.pipe(gulp.dest('dist/js'));
 });
 
 gulp.task('checked-compile', ['compile'], () => {
@@ -52,7 +44,7 @@ gulp.task('checked-compile', ['compile'], () => {
 })
 
 gulp.task('flatten', ['checked-compile'], () => {
-  return gulp.src('./dist/src/**/*.js')
+  return gulp.src('./dist/js/**/*.js')
     .pipe(gulpDotFlatten(0))
     .pipe(gulp.dest('./dist/flat'))
 });

--- a/libs/gulp-dot-flatten.js
+++ b/libs/gulp-dot-flatten.js
@@ -4,7 +4,7 @@ const path = require('path');
 const gutil = require('gulp-util');
 const through2 = require('through2');
 const PluginError = require('gulp-util').PluginError;
-const recast = require('recast')
+const recast = require('recast');
 
 module.exports = function (logAmount, stringFilter) {
   return through2.obj(function (file, enc, next) {
@@ -42,7 +42,7 @@ module.exports = function (logAmount, stringFilter) {
             } else {
               return false;
             }
-          }
+          },
         })).code);
 
         let relPath = path.dirname(file.relative).split(path.sep);
@@ -63,6 +63,7 @@ module.exports = function (logAmount, stringFilter) {
         this.emit('error', new PluginError('flatten', e));
       }
     }
+
     next();
   });
 };

--- a/libs/gulp-dot-flatten.js
+++ b/libs/gulp-dot-flatten.js
@@ -1,10 +1,11 @@
+/*jshint esversion: 6, node: true */
 'use strict';
 
 const path = require('path');
 const gutil = require('gulp-util');
 const through2 = require('through2');
 const PluginError = require('gulp-util').PluginError;
-const recast = require('recast')
+const recast = require('recast');
 
 module.exports = function (logAmount, stringFilter) {
   return through2.obj(function (file, enc, next) {
@@ -51,7 +52,7 @@ module.exports = function (logAmount, stringFilter) {
         let newName = relPath.join('.');
 
         while (newName[0] == '.') newName = newName.slice(1);
-        if (stringFilter) newName = stringFilter(result);
+        if (stringFilter) newName = stringFilter(newName);
 
         if (logAmount && logAmount > 0) {
           gutil.log(`>> flattened file '${gutil.colors.cyan(path.dirname(file.relative) + path.sep + path.basename(file.path))}' into '${gutil.colors.cyan(newName)}'`);

--- a/libs/gulp-screeps-upload.js
+++ b/libs/gulp-screeps-upload.js
@@ -1,3 +1,4 @@
+/*jshint esversion: 6, node: true */
 'use strict';
 
 const _ = require('lodash');
@@ -14,12 +15,12 @@ module.exports = (email, password, branch, logAmount) => {
     _gulpUploadVinylsAsModules(fileVinyls, cbd.makeNodeResolver(), email, password, branch, logAmount);
     return cbd.promise;
   });
-}
+};
 
 var __lastUploaded = null;
 
 function _gulpUploadVinylsAsModules(fileVinyls, cb, email, password, branch, logAmount) {
-  let modules = {}
+  let modules = {};
   for (let fileVinyl of fileVinyls) {
     let moduleName = path.basename(fileVinyl.path);
     modules[moduleName] = fileVinyl.contents.toString('utf-8');
@@ -27,7 +28,7 @@ function _gulpUploadVinylsAsModules(fileVinyls, cb, email, password, branch, log
   if (logAmount && logAmount > 0) {
     gutil.log('Modules: ');
     for (let key in modules) {
-      gutil.log(`- ${gutil.colors.cyan(key)}`)
+      gutil.log(`- ${gutil.colors.cyan(key)}`);
     }
   }
   let data = { branch: branch, modules: modules };

--- a/libs/gulp-screeps-upload.js
+++ b/libs/gulp-screeps-upload.js
@@ -14,27 +14,30 @@ module.exports = (email, password, branch, logAmount) => {
     _gulpUploadVinylsAsModules(fileVinyls, cbd.makeNodeResolver(), email, password, branch, logAmount);
     return cbd.promise;
   });
-}
+};
 
 var __lastUploaded = null;
 
 function _gulpUploadVinylsAsModules(fileVinyls, cb, email, password, branch, logAmount) {
-  let modules = {}
+  let modules = {};
   for (let fileVinyl of fileVinyls) {
     let moduleName = path.basename(fileVinyl.path);
     modules[moduleName] = fileVinyl.contents.toString('utf-8');
   }
+
   if (logAmount && logAmount > 0) {
     gutil.log('Modules: ');
     for (let key in modules) {
-      gutil.log(`- ${gutil.colors.cyan(key)}`)
+      gutil.log(`- ${gutil.colors.cyan(key)}`);
     }
   }
+
   let data = { branch: branch, modules: modules };
   if (deepEqual(__lastUploaded, data)) {
     // gutil.log('Skipping upload due to equal outputs.');
     return cb(null, {});
   }
+
   __lastUploaded = data;
 
   gutil.log(`Uploading to branch ${gutil.colors.cyan(branch)}...`);
@@ -46,8 +49,8 @@ function _gulpUploadVinylsAsModules(fileVinyls, cb, email, password, branch, log
     method: 'POST',
     auth: `${email}:${password}`,
     headers: {
-      'Content-Type': 'application/json; charset=utf-8'
-    }
+      'Content-Type': 'application/json; charset=utf-8',
+    },
   }, res => {
     gutil.log(`Build ${gutil.colors.cyan('completed')} with HTTP response ${gutil.colors.magenta(res.statusCode)}`);
     cb(null, {});

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "description": "",
   "main": "./dist/main.js",
+  "repository": "resir014/screeps-typescript-starter",
   "scripts": {
     "gulp": "gulp",
     "postinstall": "typings install",
@@ -26,8 +27,8 @@
     "q": "^1.4.1",
     "recast": "^0.11.10",
     "through2": "^2.0.1",
-    "tsconfig-glob": "^0.4.3",
     "tslint": "^3.13.0",
+    "typescript": "^2.0.0",
     "typings": "^1.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "deploy-prod": "gulp build --target prod",
     "start": "gulp watch",
     "prod": "gulp watch --target prod",
-    "test": "gulp lint",
+    "test": "gulp test",
+    "tslint": "tslint 'src/**/*.ts'; echo",
     "typings": "typings",
     "jshint-gulp": "jshint gulpfile.js libs/gulp*.js; echo"
   },

--- a/package.json
+++ b/package.json
@@ -3,32 +3,39 @@
   "version": "0.0.0",
   "description": "",
   "main": "./dist/main.js",
-  "repository": "resir014/screeps-typescript-starter",
+  "repository": "screepers/screeps-typescript-starter",
   "scripts": {
     "gulp": "gulp",
     "postinstall": "typings install",
     "deploy": "gulp build",
+    "deploy-prod": "gulp build --target prod",
     "start": "gulp watch",
+    "prod": "gulp watch --target prod",
     "test": "gulp lint",
-    "typings": "typings"
+    "typings": "typings",
+    "jshint-gulp": "jshint gulpfile.js libs/gulp*.js; echo"
   },
   "author": "",
   "license": "MIT",
   "devDependencies": {
     "deep-equal": "^1.0.1",
-    "gulp": "~3.9.0",
+    "gulp": "github:gulpjs/gulp#4.0",
     "gulp-clean": "^0.3.2",
     "gulp-collect": "^0.1.0",
     "gulp-rename": "^1.2.2",
     "gulp-tslint": "^6.0.1",
     "gulp-typescript": "^2.13.6",
     "gulp-util": "^3.0.7",
-    "lodash": "^4.13.1",
+    "jshint": "^2.9.2",
+    "lodash": "^4.14.0",
     "q": "^1.4.1",
     "recast": "^0.11.10",
     "through2": "^2.0.1",
+    "ts-loader": "^0.8.2",
     "tslint": "^3.13.0",
     "typescript": "^2.0.0",
-    "typings": "^1.3.0"
+    "typings": "^1.3.0",
+    "webpack": "^1.13.1",
+    "webpack-stream": "^3.2.0"
   }
 }

--- a/src/components/creeps/creepManager.ts
+++ b/src/components/creeps/creepManager.ts
@@ -20,7 +20,7 @@ export function loadCreeps(): void {
 
 export function createHarvester(): number | string {
   let bodyParts: string[] = [MOVE, MOVE, CARRY, WORK];
-  let name: string = null;
+  let name: string | undefined = undefined;
   let properties: { [key: string]: any } = {
     renew_station_id: SpawnManager.getFirstSpawn().id,
     role: "harvester",
@@ -43,7 +43,7 @@ export function createHarvester(): number | string {
 export function harvestersGoToWork(): void {
 
   let harvesters: Harvester[] = [];
-  _.forEach(this.creeps, function (creep: Creep, creepName: string) {
+  _.forEach(this.creeps, function (creep: Creep) {
     if (creep.memory.role === "harvester") {
       let harvester = new Harvester();
       harvester.setCreep(creep);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,30 +5,19 @@
     "removeComments": true,
     "noResolve": false,
     "noImplicitAny": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "strictNullChecks": true,
+    "noUnusedParameters": true,
+    "noUnusedLocals": true
   },
   "compileOnSave": false,
+  "include": [
+    "typings/**/*.d.ts",
+    "src/**/*.ts"
+  ],
   "exclude": [
     "dist",
     "node_modules",
     "libs"
-  ],
-  "filesGlob": [
-    "typings/**/*.d.ts",
-    "src/**/*.ts"
-  ],
-  "files": [
-    "typings/globals/lodash/index.d.ts",
-    "typings/globals/screeps/index.d.ts",
-    "typings/index.d.ts",
-    "src/components/creeps/creepAction.ts",
-    "src/components/creeps/creepManager.ts",
-    "src/components/creeps/harvester.ts",
-    "src/components/rooms/roomManager.ts",
-    "src/components/sources/sourceManager.ts",
-    "src/components/spawns/spawnManager.ts",
-    "src/config/config.ts",
-    "src/main.ts",
-    "src/shared/memoryManager.ts"
   ]
 }

--- a/typings.json
+++ b/typings.json
@@ -3,6 +3,6 @@
   "dependencies": {},
   "globalDependencies": {
     "lodash": "registry:dt/lodash#3.10.0+20160619033623",
-    "screeps": "github:screepers/Screeps-Typescript-Declarations/dist/screeps.d.ts#master"
+    "screeps": "github:screepers/Screeps-Typescript-Declarations/dist/screeps.d.ts#TS2"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,31 @@
+module.exports = {
+  entry: "./src/main.ts",
+  output: {
+    filename: "./main.js",
+    pathinfo: true,
+    libraryTarget: "commonjs2",
+  },
+
+  target: "node",
+
+  node: {
+    console: true,
+    global: true,
+    process: false,
+    Buffer: false,
+    __filename: false,
+    __dirname: false,
+  },
+
+  resolve: {
+    // Add '.ts' and '.tsx' as resolvable extensions.
+    extensions: ['', '.js', '.ts', '.d.ts', '.tsx']
+  },
+
+  module: {
+    loaders: [
+      // All files with a '.ts' or '.tsx' extension will be handled by 'ts-loader'.
+      { test: /\.tsx?$/, loader: "ts-loader" }
+    ],
+  },
+};


### PR DESCRIPTION
After this PR is merged, the `master` branch will fully transition to TypeScript 2, complete with all sorts of new features including the ability to flatten your code with Webpack. Those who still wish to use TS1 should checkout the [`ts1-legacy`](https://github.com/screepers/screeps-typescript-starter/tree/ts1-legacy) branch. Any notable changes in `master` may be backported into the legacy branch.

To learn more about TypeScript 2, [click here](https://blogs.msdn.microsoft.com/typescript/2016/07/11/announcing-typescript-2-0-beta/).
