### PR TITLE
gulp-dot-flatten.js regex to remove .ts and .js is incorrect

### DIFF
--- a/libs/gulp-dot-flatten.js
+++ b/libs/gulp-dot-flatten.js
@@ -34,7 +34,7 @@ module.exports = function (logAmount, stringFilter) {
                   if (logAmount && logAmount > 1) {
                     gutil.log(`> in file '${gutil.colors.cyan(path.dirname(file.relative) + path.sep + path.basename(file.path))}', flattened path '${gutil.colors.cyan(expr.arguments[0].value)}' into '${gutil.colors.cyan(result)}'`);
                   }
-                  result = result.replace(/.(ts|js)/g, '')
+                  result = result.replace(/[.](ts|js)/g, '')
                   expr.arguments[0] = arg.raw.charAt(0) + result + arg.raw.charAt(0);
                 } else {
                   gutil.log(`> Non Literal argument for 'require' in '${gutil.colors.cyan(path.dirname(file.relative) + path.sep + path.basename(file.path))}' location: ${arg.loc.start.line}:${arg.loc.start.column}`)


### PR DESCRIPTION
The following line does include "ts" and "js" and not just ".ts" and ".js".
`result = result.replace(/.(ts|js)/g, '')`
The dot should be escaped to be used as literal.
`result = result.replace(/[.](ts|js)/g, '')`

As example, "components" will be replaced with "compone" currently.

Since TypeScript 2 .ts line endings are not allowed in imports anyhow I would suggest to just remove this step.
However, I am not sure about .js files.

Thanks for this repository!
