### PR TITLE
change screeps typings branch to master (from TS2)

### DIFF
--- a/typings.json
+++ b/typings.json
@@ -3,6 +3,6 @@
   "dependencies": {},
   "globalDependencies": {
     "lodash": "registry:dt/lodash#3.10.0+20160619033623",
-    "screeps": "github:screepers/Screeps-Typescript-Declarations/dist/screeps.d.ts#TS2"
+    "screeps": "github:screepers/Screeps-Typescript-Declarations/dist/screeps.d.ts"
   }
 }


### PR DESCRIPTION
The master now has the TS2 typings and the old TS2 branch will be closed. See https://github.com/screepers/Screeps-Typescript-Declarations/issues/90