### PR TITLE
WIP solution to webpack not aborting on fail

### DIFF
--- a/config/config.common.ts
+++ b/config/config.common.ts
@@ -102,6 +102,9 @@ export function init(options: EnvOptions): Config {
   config.plugin("screeps-source-map")
     .use(ScreepsSourceMapToJson);
 
+  config.plugin("no-emit-on-errors")
+    .use(webpack.NoEmitOnErrorsPlugin);
+
   /////////
   /// Modules
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "module": "commonjs",
     "target": "es6",
     "removeComments": true,
+    "noEmitOnError": true,
     "noResolve": false,
     "experimentalDecorators": true,
     "strict": true,


### PR DESCRIPTION
This commit doesn't fix the issue, but it's a step forward.

`NoEmitOnErrorsPlugin` skips the emit stage of webpack when there is an error.  Currently this does nothing to solve the issue, but if Sceeps-Webpack-Plugin https://github.com/langri-sha/screeps-webpack-plugin/issues/31 is able to hook into this, then the issue could be considered solved

https://github.com/screepers/screeps-typescript-starter/issues/49