### PR TITLE
Replace old profiler with new one

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/lib/Profiler"]
+	path = src/lib/Profiler
+	url = git@github.com:screepers/screeps-typescript-profiler

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It is based on [the original starter kit](https://github.com/MarkoSulamagi/Scree
 - Pre-configured linting rules customized for screeps
 - Typescript Screeps typings
 - Logger which links with source code and git repo (TODO: pending documentation)
-- Screeps profiler
+- [Screeps profiler](https://github.com/screepers/screeps-typescript-profiler) disabled by default -- see linked documentation for usage
 - "Snippets" directory for code you want to save, but don't want compiled or linted
 - Modest starter code to get you started, but not hold your hand
 
@@ -46,6 +46,10 @@ For testing **NOTE** _Testing is currently a work-in-progress_:
 ### Download
 
 To get started, [download a zipped copy](https://github.com/screepers/screeps-typescript-starter/archive/master.zip) of the starter kit and extract it somewhere, or clone this repo.
+
+```bash
+$ git clone --recursive git@github.com:screepers/screeps-typescript-profiler.git
+```
 
 ### Install all required modules!
 

--- a/config/config.common.ts
+++ b/config/config.common.ts
@@ -96,6 +96,7 @@ export function init(options: EnvOptions): Config {
     .use(webpack.DefinePlugin, [{
       PRODUCTION: JSON.stringify(true),
       __BUILD_TIME__: JSON.stringify(Date.now()),  // example defination
+      __PROFILER_ENABLED__: JSON.stringify(true),
       __REVISION__: JSON.stringify(git.short()),
     }]);
 

--- a/package.json
+++ b/package.json
@@ -35,8 +35,6 @@
     "webpack-chain": "^3.2.0"
   },
   "dependencies": {
-    "@types/screeps-profiler": "^1.2.0",
-    "screeps-profiler": "^1.3.0",
     "source-map": "^0.5.6"
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,17 @@
 interface Memory {
   uuid: number;
   log: any;
+  P: Profiler;
+}
+
+// add objects to `global` here
+// NodeJS already declares global, so we need to extend it here:
+// tslint:disable-next-line
+declare namespace NodeJS {
+  interface Global {
+    log: any;
+    P: Profiler;
+  }
 }
 
 declare const __REVISION__: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,8 @@
 import * as CreepManager from "./components/creeps/creepManager";
-import * as Config from "./config/config";
 
-import * as Profiler from "screeps-profiler";
+// uncomment the following line if you want to use the profiler
+// import * as Profiler from "lib/Profiler";
+
 import { log } from "./lib/logger/log";
 
 // Any code written outside the `loop()` method is executed only when the
@@ -9,18 +10,13 @@ import { log } from "./lib/logger/log";
 // Use this bootstrap wisely. You can cache some of your stuff to save CPU.
 // You should extend prototypes before the game loop executes here.
 
-// This is an example for using a config variable from `config.ts`.
-// NOTE: this is used as an example, you may have better performance
-// by setting USE_PROFILER through webpack, if you want to permanently
-// remove it on deploy
-// Start the profiler
-if (Config.USE_PROFILER) {
-  Profiler.enable();
-}
+// uncomment the following line if you want to use the profiler
+// see the documentation https://github.com/screepers/screeps-typescript-profiler
+// global.P = Profiler.init();
 
 log.info(`loading revision: ${ __REVISION__ }`);
 
-function mloop() {
+function mainLoop() {
   // Check memory for null or out of bounds custom objects
   if (!Memory.uuid || Memory.uuid > 100) {
     Memory.uuid = 0;
@@ -53,4 +49,4 @@ function mloop() {
  *
  * @export
  */
-export const loop = !Config.USE_PROFILER ? mloop : Profiler.wrap(mloop);
+export const loop = mainLoop;

--- a/typings/vendor.d.ts
+++ b/typings/vendor.d.ts
@@ -1,13 +1,6 @@
 /* tslint:disable */
 // Put shims and extensions to installed modules and typings here
 
-// add objects to `global` here
-declare namespace NodeJS {
-  interface Global {
-    log: any;
-  }
-}
-
 // shim uglify-js for webpack
 declare module "uglify-js" {
   export interface MinifyOptions {}


### PR DESCRIPTION
This change is probably controversial, so lets hear feedback.

I ripped out the old profiler, and added https://github.com/screepers/screeps-typescript-profiler

It's set up with everything it needs to work, but commented out by default, since the starter doesn't include anything profilable (only classes and class-methods can be profiled).

Also updated the readme to reflect the repo needs to be cloned with `--recursive` tag