### PR TITLE
Make git optional

### DIFF
--- a/config/config.common.ts
+++ b/config/config.common.ts
@@ -1,3 +1,4 @@
+import * as fs from "fs";
 import * as path from "path";
 import * as webpack from "webpack";
 import * as Config from "webpack-chain";
@@ -24,6 +25,8 @@ export function init(options: EnvOptions): Config {
   // const TEST = options.TEST || false;
 
   const config = new Config();
+  // Check if git repo exists
+  const gitRepoExists = fs.existsSync("../.git");
 
   // set all common configurations here
   config
@@ -96,7 +99,7 @@ export function init(options: EnvOptions): Config {
     .use(webpack.DefinePlugin, [{
       PRODUCTION: JSON.stringify(true),
       __BUILD_TIME__: JSON.stringify(Date.now()),  // example defination
-      __REVISION__: JSON.stringify(git.short()),
+      __REVISION__: JSON.stringify(gitRepoExists ? git.short() : undefined),
     }]);
 
   config.plugin("screeps-source-map")

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,4 +3,4 @@ interface Memory {
   log: any;
 }
 
-declare const __REVISION__: string;
+declare const __REVISION__: string | undefined;

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,10 @@ if (Config.USE_PROFILER) {
   Profiler.enable();
 }
 
-log.info(`loading revision: ${ __REVISION__ }`);
+log.info(`Scripts bootstrapped`);
+if (__REVISION__) {
+  log.info(`Revision ID: ${__REVISION__}`);
+}
 
 function mloop() {
   // Check memory for null or out of bounds custom objects


### PR DESCRIPTION
Fixes #55.

Include a quick check to see if we have a Git repo on our current project. If not, then we skip including revision ID in the build toggles.