### PR TITLE
Do some cleanup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ Screeps Typescript Starter uses rollup to compile your typescript and upload it 
 
 Move or copy `screeps.sample.json` to `screeps.json` and edit it, changing the credentials and optionally adding or removing some of the destinations.
 
-Running `rollup -c` will compile your code and do a "dry run", preparing the code for upload but not actually pushing it. Running `rollup -c --dest main` will compile your code, and then upload it to a screeps server using the `main` config from `screeps.json`.
+Running `rollup -c` will compile your code and do a "dry run", preparing the code for upload but not actually pushing it. Running `rollup -c --environment DEST:main` will compile your code, and then upload it to a screeps server using the `main` config from `screeps.json`.
 
-You can use `-cw` instead of `-c` to automatically re-run when your source code changes - for example, `rollup -cw --dest main` will automatically upload your code to the `main` configuration every time your code is changed.
+You can use `-cw` instead of `-c` to automatically re-run when your source code changes - for example, `rollup -cw --environment DEST:main` will automatically upload your code to the `main` configuration every time your code is changed.
 
-Finally, there are also NPM scripts that serve as aliases for these commands in `package.json` for IDE integration. Running `npm run push-main` is equivalent to `rollup -c --dest main`, and `npm run watch-sim` is equivalent to `rollup -cw --dest sim`.
+Finally, there are also NPM scripts that serve as aliases for these commands in `package.json` for IDE integration. Running `npm run push-main` is equivalent to `rollup -c --environment DEST:main`, and `npm run watch-sim` is equivalent to `rollup -cw --dest sim`.
 
 #### Important! To upload code to a private server, you must have [screepsmod-auth](https://github.com/ScreepsMods/screepsmod-auth) installed and configured!
 

--- a/docs/in-depth/deploy-destinations.md
+++ b/docs/in-depth/deploy-destinations.md
@@ -37,10 +37,10 @@ The `screeps.json` file is a JSON configuration file separated into multiple dep
 }
 ```
 
-You can make as many separate destinations as you want. Just make a copy of any config object and perform the necessary changes. Once you're done, use the `--dest` argument on the `rollup` command to specify which environment to upload to.
+You can make as many separate destinations as you want. Just make a copy of any config object and perform the necessary changes. Once you're done, use the `--environment DEST:<dest>` argument on the `rollup` command to specify which environment to upload to.
 
 ```bash
-rollup -c --dest main
+rollup -c --environment DEST:main
 ```
 
-Omitting the `--dest` argument will perform a dry run, which can be used for local directories via symlinks.
+Omitting the destination will perform a dry run, which will compile and bundle the code without uploading it.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "//": "If you add or change the names of destinations in screeps.json, make sure you update these scripts to reflect the changes",
   "scripts": {
-    "lint": "tslint \"src/**/*.ts\"",
+    "lint": "tslint -p tsconfig.json \"src/**/*.ts\"",
+    "build": "rollup -c",
     "push-main": "rollup -c --environment DEST:main",
     "push-pserver": "rollup -c --environment DEST:pserver",
     "push-sim": "rollup -c --environment DEST:sim",
@@ -26,15 +27,15 @@
   "homepage": "https://github.com/screepers/screeps-typescript-starter#readme",
   "devDependencies": {
     "@types/lodash": "^3.10.1",
-    "@types/screeps": "^2.2.1",
+    "@types/screeps": "^2.3.0",
     "rollup": "^0.57.1",
-    "rollup-plugin-clean": "^1.0.0",
+    "rollup-plugin-clear": "^2.0.7",
     "rollup-plugin-commonjs": "^9.1.0",
     "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-screeps": "^0.1.2",
     "rollup-plugin-typescript2": "^0.12.0",
     "tslint": "^5.9.1",
-    "typescript": "^2.8.1"
+    "typescript": "^2.8.3"
   },
   "dependencies": {
     "source-map": "~0.6.1"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import clean from "rollup-plugin-clean";
+import clear from "rollup-plugin-clear";
 import resolve from "rollup-plugin-node-resolve";
 import commonjs from "rollup-plugin-commonjs";
 import typescript from "rollup-plugin-typescript2";
@@ -23,7 +23,7 @@ export default {
   },
 
   plugins: [
-    clean(),
+    clear({ targets: ["dist"] }),
     resolve(),
     commonjs(),
     typescript({tsconfig: "./tsconfig.json"}),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "es2015",
     "target": "es5",
+    "moduleResolution": "Node",
     "outDir": "dist",
     "baseUrl": "src/",
     "sourceMap": true,


### PR DESCRIPTION
rollup-plugin-clean doesn't work with the latest rollup, use rollup-plugin-clear instead.
Explicitly set module resolution to be Node.
Specify the tslint project which allows rules based on type info to run.
Update some dependencies to newer versions.