### PR TITLE
Add tslint-plugin-prettier to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "rollup-plugin-typescript2": "^0.16.1",
     "tslint": "^5.9.1",
     "tslint-config-prettier": "^1.14.0",
+    "tslint-plugin-prettier": "^1.3.0",
     "typescript": "^2.9.2"
   },
   "dependencies": {


### PR DESCRIPTION
Not having this causes errors with `tslint`.
I think it's better to have a description of how to add it or how to remove it 👍 

Note: This was removed on purpose by @resir014 in https://github.com/screepers/screeps-typescript-starter/commit/48ebaa49af22748a6830fe74d9de6c1ec04323bc