### PR TITLE
Update required dependencies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ You will need:
 
  - [Node.JS](https://nodejs.org/en/download) (>= 8.0.0)
  - A Package Manager ([Yarn](https://yarnpkg.com/en/docs/getting-started) or [npm](https://docs.npmjs.com/getting-started/installing-node))
- - Rollup CLI (Optional, install via `npm install -g rollup`)
+ - Rollup CLI (Optional, install via `npm install -g rollup`) 
+ - Python 2 (for node-gyp, [Python 3 is not supported](https://github.com/nodejs/node-gyp/issues/193))
+ - Build tools (`apt install build-essential` for Ubuntu, [Visual Studio](https://www.visualstudio.com/vs/) for Windows, etc) 
+
 
 Download the latest source [here](https://github.com/screepers/screeps-typescript-starter/archive/master.zip) and extract it to a folder.
 


### PR DESCRIPTION
These are required for https://github.com/Hiryus/screeps-server-mockup
Propagated from https://github.com/screeps/screeps#server-launch
Fixes #107 and #108