### PR TITLE
Remove Python requirement from ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ You will need:
  - [Node.JS](https://nodejs.org/en/download) (>= 8.0.0)
  - A Package Manager ([Yarn](https://yarnpkg.com/en/docs/getting-started) or [npm](https://docs.npmjs.com/getting-started/installing-node))
  - Rollup CLI (Optional, install via `npm install -g rollup`) 
- - Python 2 (for node-gyp, [Python 3 is not supported](https://github.com/nodejs/node-gyp/issues/193))
  - Build tools (`apt install build-essential` for Ubuntu, [Visual Studio](https://www.visualstudio.com/vs/) for Windows, etc) 
 
 


### PR DESCRIPTION
 `screeps-server-mockup` is removed in #113, which relied on `screeps` and in turn on `node-gyp`, which required Python 2.
No other packages depend on Python 2. Since #113 is merged, Python 2 is no longer required for this repository. 

This PR updates the repository's readme accordingly.