### PR TITLE
Fix version rollup plugin commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "rollup": "^0.63.4",
     "rollup-plugin-buble": "^0.19.4",
     "rollup-plugin-clear": "^2.0.7",
-    "rollup-plugin-commonjs": "^8.1.4",
+    "rollup-plugin-commonjs": "^8.4.1",
     "rollup-plugin-multi-entry": "^2.0.2",
     "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-nodent": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "rollup": "^0.63.4",
     "rollup-plugin-buble": "^0.19.4",
     "rollup-plugin-clear": "^2.0.7",
-    "rollup-plugin-commonjs": "^9.1.4",
+    "rollup-plugin-commonjs": "^8.1.4",
     "rollup-plugin-multi-entry": "^2.0.2",
     "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-nodent": "^0.2.2",


### PR DESCRIPTION
Currently, `package.json` sets the version of `rollup-plugin-commonjs` to `9.1.4`. This PR rolls back to `8.4.1`. 

When following the starter kit install instructions, the result is non-functional. 

Running `npm install` runs fine, but following it with `rollup -c` (no other changes made) gives the following output and error:

```
PS C:\Users\tcdej\Documents\Repositories\screeps-typescript-starter> npm install

> bufferutil@3.0.5 install C:\Users\tcdej\Documents\Repositories\screeps-typescript-starter\node_modules\bufferutil
> prebuild-install || node-gyp rebuild


> utf-8-validate@4.0.2 install C:\Users\tcdej\Documents\Repositories\screeps-typescript-starter\node_modules\utf-8-validate
> prebuild-install || node-gyp rebuild

npm notice created a lockfile as package-lock.json. You should commit this file.
added 272 packages from 1093 contributors and audited 596 packages in 10.355s
found 4 vulnerabilities (2 low, 2 high)
  run `npm audit fix` to fix them, or `npm audit` for details
PS C:\Users\tcdej\Documents\Repositories\screeps-typescript-starter> rollup -c
No destination specified - code will be compiled but not uploaded

src/main.ts → dist/main.js...
[!] (commonjs plugin) TypeError: parse is not a function in C:\Users\tcdej\Documents\Repositories\screeps-typescript-starter\node_modules\source-map\source-map.js
node_modules\source-map\source-map.js
TypeError: parse is not a function in C:\Users\tcdej\Documents\Repositories\screeps-typescript-starter\node_modules\source-map\source-map.js
    at error (C:\Users\tcdej\AppData\Roaming\npm\node_modules\rollup\dist\rollup.js:170:15)
    at C:\Users\tcdej\AppData\Roaming\npm\node_modules\rollup\dist\rollup.js:17527:17
```

As you see, the unchanged main.js could not be compiled. Reverting the plugin solves this issue. The following is from after the suggested commit:

```
PS C:\Users\tcdej\Documents\Repositories\screeps-typescript-starter> npm install
npm WARN deprecated rollup-plugin-commonjs@8.4.1: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-commonjs.
added 4 packages from 78 contributors, updated 1 package and audited 597 packages in 1.911s
found 4 vulnerabilities (2 low, 2 high)
  run `npm audit fix` to fix them, or `npm audit` for details
PS C:\Users\tcdej\Documents\Repositories\screeps-typescript-starter> rollup -c
No destination specified - code will be compiled but not uploaded

src/main.ts → dist/main.js...
created dist/main.js in 2s
```

That said, the entire `rollup-plugin-commonjs` is deprecated. An alternative to this PR would be updating rollup itself to `^1.20.0` and switching to `@rollup/plugin-common-js` and all other dependencies. This PR can serve as a band-aid in the meantime. 