### PR TITLE
Fixed Mocha from exiting before reporter has a chance to print error

### DIFF
--- a/test/integration/helper.ts
+++ b/test/integration/helper.ts
@@ -56,8 +56,4 @@ before(() => {
   stdHooks.hookWrite();
 });
 
-after(() => {
-  process.exit();
-});
-
 export const helper = new IntegrationTestHelper();

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -10,3 +10,4 @@
 
 --recursive
 --timeout 5000
+--exit


### PR DESCRIPTION
Calling `process.exit()` in the `after()` hook will exit the test runner before the spec reporter has a chance to print the error message and stack trace to help you debug the failure.

Using the `--exit` Mocha option will still exit the process, but after the reporter has run.

Before:
```
  main
    ✓ runs a server and matches the game tick (373ms)
    ✓ writes and reads to memory (217ms)
    1) should fail (<- colored red, that's all)
```

After:
```
  main
    ✓ runs a server and matches the game tick (373ms)
    ✓ writes and reads to memory (217ms)
    1) should fail


  2 passing (1s)
  1 failing

  1) main
       should fail:

      AssertionError: expected false to equal true
      + expected - actual

      -false
      +true

      at Context.<anonymous> (/Users/brisberg/DevProjects/amber/test/integration/integration.test.ts:20:12)
      at callFn (/Users/brisberg/DevProjects/amber/node_modules/mocha/lib/runnable.js:387:21)
      at Test.Runnable.run (/Users/brisberg/DevProjects/amber/node_modules/mocha/lib/runnable.js:379:7)
```