### PR TITLE
Integration testing cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ You will need:
 
  - [Node.JS](https://nodejs.org/en/download) (>= 8.0.0)
  - A Package Manager ([Yarn](https://yarnpkg.com/en/docs/getting-started) or [npm](https://docs.npmjs.com/getting-started/installing-node))
- - Rollup CLI (Optional, install via `npm install -g rollup`) 
- - Build tools (`apt install build-essential` for Ubuntu, [Visual Studio](https://www.visualstudio.com/vs/) for Windows, etc) 
-
+ - Rollup CLI (Optional, install via `npm install -g rollup`)
 
 Download the latest source [here](https://github.com/screepers/screeps-typescript-starter/archive/master.zip) and extract it to a folder.
 

--- a/docs/in-depth/testing.md
+++ b/docs/in-depth/testing.md
@@ -53,10 +53,8 @@ In `package.json`, add a new `test-integration` script and add the new integrati
 
 ```json
   "scripts": {
-    ...
     "test": "npm run test-unit && npm run test-integration",
     "test-integration": "npm run build && rollup -c rollup.test-integration-config.js && mocha dist/test-integration.bundle.js",
-    ...
   }
 ```
 

--- a/docs/in-depth/testing.md
+++ b/docs/in-depth/testing.md
@@ -42,13 +42,35 @@ magnitude, it is recommended to prefer unit tests wherever possible.
 
 ## Integration Testing
 
+### Installing Screeps Server Mockup
+
+Before starting to use integration testing, you must install [screeps-server-mockup](https://github.com/screepers/screeps-server-mockup) to your project.
+Please view that repository for more instruction on installation.
+
+You will also need to add scripts to run integration tests.
+
+In `package.json`, add a new `test-integration` script and add the new integration testing to the main `test` script.
+
+```json
+  "scripts": {
+    ...
+    "test": "npm run test-unit && npm run test-integration",
+    "test-integration": "npm run build && rollup -c rollup.test-integration-config.js && mocha dist/test-integration.bundle.js",
+    ...
+  }
+```
+
+Now you can run integration tests by using the `test-integration` script or run both unit and integration tests using the `test` script.
+
+### Integration Testing with Screeps Server Mockup
+
 Integration testing is for code that depends heavily on having a full game
 environment. Integration tests are completely representative of the real game
 (in fact they run with an actual Screeps server). This comes at the cost of
 performance and very involved setup when creating specific scenarios.
 
 Server testing support is implmented via
-[screeps-server-mockup](https://github.com/Hiryus/screeps-server-mockup). View
+[screeps-server-mockup](https://github.com/screepers/screeps-server-mockup). View
 this repository for more information on the API.
 
 By default the test helper will create a "stub" world with a 3x3 grid of rooms

--- a/docs/in-depth/testing.md
+++ b/docs/in-depth/testing.md
@@ -47,6 +47,13 @@ magnitude, it is recommended to prefer unit tests wherever possible.
 Before starting to use integration testing, you must install [screeps-server-mockup](https://github.com/screepers/screeps-server-mockup) to your project.
 Please view that repository for more instruction on installation.
 
+```bash
+# Using yarn:
+yarn add -D screeps-server-mockup
+# Using npm
+npm install --save-dev screeps-server-mockup
+```
+
 You will also need to add scripts to run integration tests.
 
 In `package.json`, add a new `test-integration` script and add the new integration testing to the main `test` script.
@@ -67,7 +74,7 @@ environment. Integration tests are completely representative of the real game
 (in fact they run with an actual Screeps server). This comes at the cost of
 performance and very involved setup when creating specific scenarios.
 
-Server testing support is implmented via
+Server testing support is implemented via
 [screeps-server-mockup](https://github.com/screepers/screeps-server-mockup). View
 this repository for more information on the API.
 

--- a/package.json
+++ b/package.json
@@ -10,9 +10,8 @@
     "push-main": "rollup -c --environment DEST:main",
     "push-pserver": "rollup -c --environment DEST:pserver",
     "push-sim": "rollup -c --environment DEST:sim",
-    "test": "npm run test-unit && npm run test-integration",
+    "test": "npm run test-unit",
     "test-unit": "rollup -c rollup.test-unit-config.js && mocha dist/test-unit.bundle.js",
-    "test-integration": "npm run build && rollup -c rollup.test-integration-config.js && mocha dist/test-integration.bundle.js",
     "watch-main": "rollup -cw --environment DEST:main",
     "watch-pserver": "rollup -cw --environment DEST:pserver",
     "watch-sim": "rollup -cw --environment DEST:sim"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "push-sim": "rollup -c --environment DEST:sim",
     "test": "npm run test-unit",
     "test-unit": "rollup -c rollup.test-unit-config.js && mocha dist/test-unit.bundle.js",
+    "test-integration": "echo 'See docs/in-depth/testing.md for instructions on enabling integration tests'",
     "watch-main": "rollup -cw --environment DEST:main",
     "watch-pserver": "rollup -cw --environment DEST:pserver",
     "watch-sim": "rollup -cw --environment DEST:sim"


### PR DESCRIPTION
The goal is to keep the framework for integration testing but not require screeps-server-mockup by default. Instead, to instruct users how to install the dependency themselves. 

- Adds instructions to install `screeps-server-mockup` and adding test scripts
- Removes `test-integration` script
- Removes integration from `test` script
