### PR TITLE
Specified Node 10.x as engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,14 @@
     "url": "https://github.com/screepers/screeps-typescript-starter/issues"
   },
   "homepage": "https://github.com/screepers/screeps-typescript-starter#readme",
+  "engines": {
+    "node": "10.x"
+  },
   "devDependencies": {
     "@types/chai": "^4.1.6",
     "@types/lodash": "^3.10.1",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.5.5",
+    "@types/node": "^10.17.18",
     "@types/screeps": "^3.0.0",
     "@types/sinon": "^5.0.5",
     "@types/sinon-chai": "^3.2.0",


### PR DESCRIPTION
The Screeps Runtime now runs on Node10 (as of [Oct 2019](https://screeps.com/forum/topic/2800/new-server-cluster)) .

I found that some auxilary libraries that I've been using but not included in this starter work better if compiled with Node 10.

Better to require that users have node 10 installed. Optionally, users could use NVM to include multiple node versions on their machine at once. I could include dome docs for that if you'd like.