### PR TITLE
Changed mock Game.creeps and Memory.creeps to object

### DIFF
--- a/test/unit/mock.ts
+++ b/test/unit/mock.ts
@@ -1,10 +1,10 @@
 export const Game = {
-  creeps: [],
+  creeps: {},
   rooms: [],
   spawns: {},
   time: 12345
 };
 
 export const Memory = {
-  creeps: []
+  creeps: {}
 };


### PR DESCRIPTION
Changed the types of mock.ts `Game.creeps` and `Memory.Creeps` to object type, because they are hashes in the real implementation, not arrays.

This would potentially break tests, but to me it seems like this typing makes more sense.