### PR TITLE
Update node version from 10.x to >=10.x in package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /tsc-out
 /node_modules
 /_book
+/build/*
 
 # TypeScript definitions installed by Typings
 /typings

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Screeps Typescript Starter is a starting point for a Screeps AI written in Types
 
 You will need:
 
-- [Node.JS](https://nodejs.org/en/download) (>= 10.0.0)
+- [Node.JS](https://nodejs.org/en/download) (10.x)
 - A Package Manager ([Yarn](https://yarnpkg.com/en/docs/getting-started) or [npm](https://docs.npmjs.com/getting-started/installing-node))
 - Rollup CLI (Optional, install via `npm install -g rollup`)
 - Build tools (`apt install build-essential` for Ubuntu, [Visual Studio](https://www.visualstudio.com/vs/) for Windows, etc)

--- a/README.md
+++ b/README.md
@@ -6,11 +6,10 @@ Screeps Typescript Starter is a starting point for a Screeps AI written in Types
 
 You will need:
 
- - [Node.JS](https://nodejs.org/en/download) (>= 8.0.0)
- - A Package Manager ([Yarn](https://yarnpkg.com/en/docs/getting-started) or [npm](https://docs.npmjs.com/getting-started/installing-node))
- - Rollup CLI (Optional, install via `npm install -g rollup`) 
- - Build tools (`apt install build-essential` for Ubuntu, [Visual Studio](https://www.visualstudio.com/vs/) for Windows, etc) 
-
+- [Node.JS](https://nodejs.org/en/download) (>= 10.0.0)
+- A Package Manager ([Yarn](https://yarnpkg.com/en/docs/getting-started) or [npm](https://docs.npmjs.com/getting-started/installing-node))
+- Rollup CLI (Optional, install via `npm install -g rollup`)
+- Build tools (`apt install build-essential` for Ubuntu, [Visual Studio](https://www.visualstudio.com/vs/) for Windows, etc)
 
 Download the latest source [here](https://github.com/screepers/screeps-typescript-starter/archive/master.zip) and extract it to a folder.
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/screepers/screeps-typescript-starter#readme",
   "engines": {
-    "node": ">=10.x"
+    "node": "10.x"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.1.0",
@@ -45,7 +45,7 @@
     "lodash": "^3.10.1",
     "mocha": "^5.2.0",
     "prettier": "^2.0.4",
-    "rollup": "^1.32.1",
+    "rollup": "^2.6.1",
     "rollup-plugin-buble": "^0.19.8",
     "rollup-plugin-clear": "^2.0.7",
     "rollup-plugin-nodent": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lodash": "^3.10.1",
     "mocha": "^5.2.0",
     "prettier": "^2.0.4",
-    "rollup": "^2.6.1",
+    "rollup": "^1.32.1",
     "rollup-plugin-buble": "^0.19.8",
     "rollup-plugin-clear": "^2.0.7",
     "rollup-plugin-nodent": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/screepers/screeps-typescript-starter#readme",
   "engines": {
-    "node": "10.x"
+    "node": ">=10.x"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.1.0",


### PR DESCRIPTION
I changed
```
"engines": {
    "node": "10.x"
  },
```

to   
```
"engines": {
    "node": ">=10.x"
  },
```

because I had this error
```
λ yarn install
yarn install v1.22.4
[1/5] Validating package.json...
error screeps-typescript-starter@3.0.0: The engine "node" is incompatible with this module. Expected version "10.x". Got "12.16.1"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```
using my current node version (12.x) on Windows 10.

I am assuming the 10x version lock was not for any particular reason, and that anything Node 10 or newer should work fine. 