### PR TITLE
Added docs and config for pushing to seasonal server

### DIFF
--- a/docs/in-depth/deploy-destinations.md
+++ b/docs/in-depth/deploy-destinations.md
@@ -2,12 +2,13 @@
 
 The `screeps.json` file is a JSON configuration file separated into multiple deploy destinations. We've given you four primary destinations by default.
 
+See [here](/docs/getting-started/authenticating.md) for steps to generate your API token.
+
 ```javascript
 {
   // Used for deploying to the main world
   "main": {
-    "email": "you@provider.tld",
-    "password": "Password",
+    "token": "YOUR_TOKEN",
     "protocol": "https",
     "hostname": "screeps.com",
     "port": 443,
@@ -16,8 +17,7 @@ The `screeps.json` file is a JSON configuration file separated into multiple dep
   },
   // Used for deploying to Simulation mode
   "sim": {
-    "email": "you@provider.tld",
-    "password": "Password",
+    "token": "YOUR_TOKEN",
     "protocol": "https",
     "hostname": "screeps.com",
     "port": 443,
@@ -26,8 +26,7 @@ The `screeps.json` file is a JSON configuration file separated into multiple dep
   },
   // Used for deploying to Seasonal Event server
   "season": {
-    "email": "you@provider.tld",
-    "password": "Password",
+    "token": "YOUR_TOKEN",
     "protocol": "https",
     "hostname": "screeps.com",
     "port": 443,
@@ -36,8 +35,7 @@ The `screeps.json` file is a JSON configuration file separated into multiple dep
   },
   // Used for deploying to a private server
   "pserver": {
-    "email": "username",
-    "password": "Password",
+    "token": "YOUR_TOKEN",
     "protocol": "http",
     "hostname": "1.2.3.4",
     "port": 21025,

--- a/docs/in-depth/deploy-destinations.md
+++ b/docs/in-depth/deploy-destinations.md
@@ -1,6 +1,6 @@
 # Deploy destinations
 
-The `screeps.json` file is a JSON configuration file separated into multiple deploy destinations. We've given you three primary destinations by default.
+The `screeps.json` file is a JSON configuration file separated into multiple deploy destinations. We've given you four primary destinations by default.
 
 ```javascript
 {
@@ -24,6 +24,16 @@ The `screeps.json` file is a JSON configuration file separated into multiple dep
     "path": "/",
     "branch": "sim"
   },
+  // Used for deploying to Seasonal Event server
+  "season": {
+    "email": "you@provider.tld",
+    "password": "Password",
+    "protocol": "https",
+    "hostname": "screeps.com",
+    "port": 443,
+    "path": "/season",
+    "branch": "main"
+  },
   // Used for deploying to a private server
   "pserver": {
     "email": "username",
@@ -44,4 +54,3 @@ rollup -c --environment DEST:main
 ```
 
 Omitting the destination will perform a dry run, which will compile and bundle the code without uploading it.
-

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
     "build": "rollup -c",
     "push-main": "rollup -c --environment DEST:main",
     "push-pserver": "rollup -c --environment DEST:pserver",
+    "push-season": "rollup -c --environment DEST:season",
     "push-sim": "rollup -c --environment DEST:sim",
     "test": "npm run test-unit",
     "test-unit": "mocha test/unit/**/*.ts",
     "test-integration": "echo 'See docs/in-depth/testing.md for instructions on enabling integration tests'",
     "watch-main": "rollup -cw --environment DEST:main",
     "watch-pserver": "rollup -cw --environment DEST:pserver",
+    "watch-season": "rollup -cw --environment DEST:season",
     "watch-sim": "rollup -cw --environment DEST:sim"
   },
   "repository": {

--- a/screeps.sample.json
+++ b/screeps.sample.json
@@ -15,6 +15,14 @@
     "path": "/",
     "branch": "sim"
   },
+  "season": {
+    "token": "YOUR_TOKEN",
+    "protocol": "https",
+    "hostname": "screeps.com",
+    "port": 443,
+    "path": "/season",
+    "branch": "main"
+  },
   "pserver": {
     "email": "username",
     "password": "Password",


### PR DESCRIPTION
The underlying Screeps-API package can already access the Seasonal Event server. This just adds documentation and default configs for accessing the seasonal server.

See: https://github.com/screeps/grunt-screeps/blob/master/tasks/screeps.js#L19 for `/season` path.

--

It is possible that this adds too much noise for a new player just starting out, but I feel most players interested enough to start during the seasonal events will want an easy way to commit their code.

Let me know if you feel this should be omitted from the default configs and moved to Docs only as an advanced config option.