### PR TITLE
Update .eslintrc.js to prevent false positives

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -73,7 +73,7 @@ module.exports = {
     "no-invalid-this": "off",
     "no-multiple-empty-lines": "off",
     "no-new-wrappers": "error",
-    "no-shadow": "off"
+    "no-shadow": "off",
     "no-throw-literal": "error",
     "no-trailing-spaces": "off",
     "no-undef-init": "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,6 +41,12 @@ module.exports = {
     ],
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-parameter-properties": "off",
+    "@typescript-eslint/no-shadow": [
+      "error",
+      {
+        hoist: "all"
+      }
+    ],
     "@typescript-eslint/no-unused-expressions": "error",
     "@typescript-eslint/no-use-before-define": ["error", { functions: false }],
     "@typescript-eslint/prefer-for-of": "error",
@@ -67,12 +73,7 @@ module.exports = {
     "no-invalid-this": "off",
     "no-multiple-empty-lines": "off",
     "no-new-wrappers": "error",
-    "no-shadow": [
-      "error",
-      {
-        hoist: "all"
-      }
-    ],
+    "no-shadow": "off"
     "no-throw-literal": "error",
     "no-trailing-spaces": "off",
     "no-undef-init": "error",


### PR DESCRIPTION
Utilizing eslint "no-shadow" rule yields false positives for enums (claims that they were declared in an upper scope, error "no-shadow"

Utilize @typescript-eslint/no-shadow corrects this issue.

Create an enum to replicate the issue, or view the following issue for an example (and the suggested fix in this PR) on the typescript-eslint repo itself.

https://github.com/typescript-eslint/typescript-eslint/issues/2483