### PR TITLE
Bump rollup-plugin-typescript2 to fix nodejs 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "rollup": "^2.56.2",
     "rollup-plugin-clear": "^2.0.7",
     "rollup-plugin-screeps": "^1.0.1",
-    "rollup-plugin-typescript2": "^0.30.0",
+    "rollup-plugin-typescript2": "^0.31.0",
     "sinon": "^6.3.5",
     "sinon-chai": "^3.2.0",
     "ts-node": "^10.2.0",


### PR DESCRIPTION
Running `npm run push-main` gives this with nodejs 17:

> Package subpath './package.json' is not defined by "exports" in /home/wouldntyouliketoknow/node_modules/tslib/package.json

This change incorporates [the fix](https://github.com/ezolenko/rollup-plugin-typescript2/issues/286) from rollup-plugin-typescript2 v0.31.0.

Please feel free to merge for me.