### PR TITLE
Update rollup-plugin-typescript2 to v0.34.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "rollup": "^2.56.2",
     "rollup-plugin-clear": "^2.0.7",
     "rollup-plugin-screeps": "^1.0.1",
-    "rollup-plugin-typescript2": "^0.30.0",
+    "rollup-plugin-typescript2": "^0.34.1",
     "sinon": "^6.3.5",
     "sinon-chai": "^3.2.0",
     "ts-node": "^10.2.0",


### PR DESCRIPTION
This fixes the "tslib" package.json not being defined correctly bug.
This is a direct fix to https://github.com/screepers/screeps-typescript-starter/issues/169

Previous error:
PS C:\code\temp\lllllllll\screeps-typescript-starter> npm run push-pserver

> screeps-typescript-starter@3.0.0 push-pserver
> rollup -c --environment DEST:pserver

Error loading `tslib` helper library.
[!] Error: Package subpath './package.json' is not defined by "exports" in C:\code\temp\lllllllll\screeps-typescript-starter\node_modules\tslib\package.json
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not defined by "exports" in C:\code\temp\lllllllll\screeps-typescript-starter\node_modules\tslib\package.json
    at new NodeError (node:internal/errors:399:5)
    at exportsNotFound (node:internal/modules/esm/resolve:361:10)
    at resolveExports (node:internal/modules/cjs/loader:538:36)
    at Module._findPath (node:internal/modules/cjs/loader:607:31)
    at Module._resolveFilename (node:internal/modules/cjs/loader:1033:27)
    at Module._load (node:internal/modules/cjs/loader:893:27)
    at Module.require (node:internal/modules/cjs/loader:1113:19)
    at require (node:internal/modules/cjs/helpers:103:18)
    at Object.<anonymous> (C:\code\temp\lllllllll\screeps-typescript-starter\node_modules\rollup-plugin-typescript2\dist\rollup-plugin-typescript2.cjs.js:25170:26)