### PR TITLE
Fix rollup errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "screeps-typescript-starter",
+  "type": "module",
   "version": "3.0.0",
   "description": "",
   "main": "index.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,8 +10,12 @@ let cfg;
 const dest = process.env.DEST;
 if (!dest) {
   console.log("No destination specified - code will be compiled but not uploaded");
-} else if ((cfg = require("./screeps.json")[dest]) == null) {
-  throw new Error("Invalid upload destination");
+} else {
+  const screepsData = await import( "./screeps.json", { with: { type: "json" } } );
+  cfg = screepsData.default[dest];
+  if (cfg == null) {
+    throw new Error("Invalid upload destination");
+  }
 }
 
 export default {


### PR DESCRIPTION
On a fresh clone of this repo, `rollup -c` fails with errors related to ES/CJS problems.

```
(node:1224971) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///home/sparr/src/games/Screeps/codebases/2025/rollup.config.js is not specified and it doesn't parse as CommonJS.
Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
To eliminate this warning, add "type": "module" to /home/sparr/src/games/Screeps/codebases/2025/package.json.
```

And then there are further errors that I failed to capture, related to the use of `require`.

This PR updates the package.json and replaces `require` in the rollup config.