### PR TITLE
Fix typo in comments for clarity in global type definitions

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ declare global {
   }
 
 }
-// Syntax for adding proprties to `global` (ex "global.log")
+// Syntax for adding properties to `global` (ex "global.log")
 declare const global: {
   log: any;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,8 +3,8 @@ import { ErrorMapper } from "utils/ErrorMapper";
 declare global {
   /*
     Example types, expand on these or remove them and add your own.
-    Note: Values, properties defined here do no fully *exist* by this type definiton alone.
-          You must also give them an implemention if you would like to use them. (ex. actually setting a `role` property in a Creeps memory)
+    Note: Values, properties defined here do no fully *exist* by this type definition alone.
+          You must also give them an implementation if you would like to use them. (ex. actually setting a `role` property in a Creeps memory)
 
     Types added in this `global` block are in an ambient, global context. This is needed because `main.ts` is a module file (uses import or export).
     Interfaces matching on name from @types/screeps will be merged. This is how you can extend the 'built-in' interfaces from @types/screeps.


### PR DESCRIPTION
Just fixed some small typos in the scr/main.ts file;

Thanks for making this startup project available. I'm just getting back to Screeps and this TypeScript quickstart will very much come in handy.

