### PR TITLE
Update dev container and dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:12-bullseye
 
 # Install dependencies
 RUN apt-get update && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,12 @@
-FROM node:12-alpine
+FROM node:18
 
-RUN apk add --update --no-cache git ca-certificates openssl openssh
+# Install dependencies
+RUN apt-get update && \
+  apt-get install -y \
+  git \
+  ca-certificates \
+  openssl \
+  openssh-client
+
+# Install global npm packages
 RUN npm install -g rollup

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-bullseye
+FROM node:12-bullseye-slim
 
 # Install dependencies
 RUN apt-get update && \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,31 +1,25 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.166.0/containers/docker-existing-dockerfile
+// For format details, see https://containers.dev/implementors/json_reference/.
 {
   "name": "Screeps-TypeScript-Starter",
-
   // Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
   "dockerFile": "Dockerfile",
-
   // Set *default* container specific settings.json values on container create.
-  "settings": {
-    "terminal.integrated.shell.linux": null
-  },
-
-  // Add the IDs of extensions you want installed when the container is created.
-  "extensions": []
-
+  "customizations": {
+    "vscode": {
+      "extensions": [],
+      "settings": {
+        "terminal.integrated.shell.linux": null
+      }
+    }
+  }
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
-
   // Uncomment the next line to run commands after the container is created - for example installing curl.
   // "postCreateCommand": "apt-get update && apt-get install -y curl",
-
   // Uncomment when using a ptrace-based debugger like C++, Go, and Rust
   // "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
-
   // Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
   // "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
-
   // Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
   // "remoteUser": "vscode"
 }


### PR DESCRIPTION
The current dev container configuration is quite old and does not work anymore. This PR updates it to a container image which VS code supports (Debian 11 vs Alpine 3.15 in the 12-Alpine image used previously). It also updates the devcontainer.json format to respect the current format preferred by VS Code.