### PR TITLE
Fix broken build

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,10 +1,10 @@
 "use strict";
 
 import clear from 'rollup-plugin-clear';
-import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
-import typescript from 'rollup-plugin-typescript2';
+import resolve from '@rollup/plugin-node-resolve';
 import screeps from 'rollup-plugin-screeps';
+import typescript from 'rollup-plugin-typescript2';
 
 let cfg;
 const dest = process.env.DEST;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,7 +26,7 @@ export default {
     clear({ targets: ["dist"] }),
     resolve({ rootDir: "src" }),
     commonjs(),
-    typescript({tsconfig: "./tsconfig.json"}),
+    typescript({ tsconfig: "./tsconfig.json", include: ["**/*.ts"], exclude: [] }),
     screeps({config: cfg, dryRun: cfg == null})
   ]
 }


### PR DESCRIPTION
First commit fixes ESLint errors about import ordering.

Second commit fixes:
```
> screeps-typescript-starter@3.0.0 push-pserver
> rollup -c --environment DEST:pserver

cleared:  $SRCROOT/ts-starter/dist

src/main.ts → dist/main.js...
[!] Error: Unexpected token (Note that you need plugins to import files that are not JavaScript)
src/main.ts (3:8)
1: import { ErrorMapper } from "utils/ErrorMapper";
2: 
3: declare global {
           ^
4:   /*
5:     Example types, expand on these or remove them and add your own.
Error: Unexpected token (Note that you need plugins to import files that are not JavaScript)
    at error ($SRCROOT/ts-starter/node_modules/rollup/dist/shared/rollup.js:198:30)
    at Module.error (/$SRCROOT/ts-starter/node_modules/rollup/dist/shared/rollup.js:12567:16)
    at Module.tryParse ($SRCROOT/ts-starter/node_modules/rollup/dist/shared/rollup.js:12944:25)
    at Module.setSource ($SRCROOT/ts-starter/node_modules/rollup/dist/shared/rollup.js:12849:24)
    at ModuleLoader.addModuleSource ($SRCROOT/ts-starter/node_modules/rollup/dist/shared/rollup.js:22120:20)
```